### PR TITLE
Add manager POM/tests and extra Wizard Bank coverage

### DIFF
--- a/src/pages/BankHomePage.js
+++ b/src/pages/BankHomePage.js
@@ -1,10 +1,11 @@
-import { expect } from '@playwright/test';
-
 export class BankHomePage {
   constructor(page) {
     this.page = page;
     this.customerLoginButton = page.getByRole('button', {
       name: 'Customer Login',
+    });
+    this.bankManagerLoginButton = page.getByRole('button', {
+      name: 'Bank Manager Login',
     });
   }
 
@@ -14,5 +15,9 @@ export class BankHomePage {
 
   async clickCustomerLoginButton() {
     await this.customerLoginButton.click();
+  }
+
+  async clickBankManagerLoginButton() {
+    await this.bankManagerLoginButton.click();
   }
 }

--- a/src/pages/customer/CustomerAccountPage.js
+++ b/src/pages/customer/CustomerAccountPage.js
@@ -34,6 +34,10 @@ export class CustomerAccountPage {
     await this.page.goto('/angularJs-protractor/BankingProject/#/account');
   }
 
+  async selectAccount(accountId) {
+    await this.accountIdDropDown.selectOption(accountId);
+  }
+
   async assertAccountIdInDropDownHasValue(value) {
     const accountNumberInDrodown = this.accountIdDropDown;
     await expect(accountNumberInDrodown).toHaveValue(value);

--- a/src/pages/customer/CustomerAccountPage.js
+++ b/src/pages/customer/CustomerAccountPage.js
@@ -26,6 +26,7 @@ export class CustomerAccountPage {
     this.withdrawNoBalanceErrorMessage = page.getByText(
       'Transaction Failed. You can not withdraw amount more than the balance.',
     );
+    this.withdrawSuccessfulMessage = page.getByText(/Transaction successful/i);
     this.logoutButton = page.getByRole('button', { name: 'Logout' });
   }
 
@@ -38,8 +39,8 @@ export class CustomerAccountPage {
     await expect(accountNumberInDrodown).toHaveValue(value);
   }
 
-  async assertAccountLineContainsText(text) {
-    await expect(this.accountDataLine).toContainText(text);
+  async assertAccountLineContainsText(text, options = {}) {
+    await expect(this.accountDataLine).toContainText(text, options);
   }
 
   async clickDepositButton() {
@@ -76,5 +77,9 @@ export class CustomerAccountPage {
 
   async assertWithdrawNoBalanceErrorMessageIsVisible() {
     await expect(this.withdrawNoBalanceErrorMessage).toBeVisible();
+  }
+
+  async assertWithdrawSuccessfulMessageIsVisible() {
+    await expect(this.withdrawSuccessfulMessage).toBeVisible({ timeout: 10000 });
   }
 }

--- a/src/pages/manager/AddCustomerPage.js
+++ b/src/pages/manager/AddCustomerPage.js
@@ -1,13 +1,40 @@
-import { expect } from '@playwright/test';
-
 export class AddCustomerPage {
   constructor(page) {
     this.page = page;
+    this.firstNameInput = page.getByPlaceholder('First Name');
+    this.lastNameInput = page.getByPlaceholder('Last Name');
+    this.postalCodeInput = page.getByPlaceholder('Post Code');
+    this.addCustomerFormButton = page.getByRole('form').getByRole('button', {
+      name: 'Add Customer',
+    });
   }
 
   async open() {
     await this.page.goto(
       '/angularJs-protractor/BankingProject/#/manager/addCust',
     );
+  }
+
+  async fillFirstName(firstName) {
+    await this.firstNameInput.fill(firstName);
+  }
+
+  async fillLastName(lastName) {
+    await this.lastNameInput.fill(lastName);
+  }
+
+  async fillPostalCode(postalCode) {
+    await this.postalCodeInput.fill(postalCode);
+  }
+
+  async clickAddCustomerButton() {
+    await this.addCustomerFormButton.click();
+  }
+
+  async addCustomer(firstName, lastName, postalCode) {
+    await this.fillFirstName(firstName);
+    await this.fillLastName(lastName);
+    await this.fillPostalCode(postalCode);
+    await this.clickAddCustomerButton();
   }
 }

--- a/src/pages/manager/BankManagerMainPage.js
+++ b/src/pages/manager/BankManagerMainPage.js
@@ -3,9 +3,36 @@ import { expect } from '@playwright/test';
 export class BankManagerMainPage {
   constructor(page) {
     this.page = page;
+    this.addCustomerButton = page.getByRole('button', { name: 'Add Customer' });
+    this.openAccountButton = page.getByRole('button', { name: 'Open Account' });
+    this.customersButton = page.getByRole('button', { name: 'Customers' });
   }
 
   async open() {
     await this.page.goto('/angularJs-protractor/BankingProject/#/manager');
+  }
+
+  async clickAddCustomerButton() {
+    await this.addCustomerButton.click();
+  }
+
+  async clickOpenAccountButton() {
+    await this.openAccountButton.click();
+  }
+
+  async clickCustomersButton() {
+    await this.customersButton.click();
+  }
+
+  async assertAddCustomerButtonIsVisible() {
+    await expect(this.addCustomerButton).toBeVisible();
+  }
+
+  async assertOpenAccountButtonIsVisible() {
+    await expect(this.openAccountButton).toBeVisible();
+  }
+
+  async assertCustomersButtonIsVisible() {
+    await expect(this.customersButton).toBeVisible();
   }
 }

--- a/src/pages/manager/CustomersListPage.js
+++ b/src/pages/manager/CustomersListPage.js
@@ -3,9 +3,71 @@ import { expect } from '@playwright/test';
 export class CustomersListPage {
   constructor(page) {
     this.page = page;
+    this.searchInput = page.getByPlaceholder('Search Customer');
+    this.tableRows = page.getByRole('row').filter({ hasNotText: 'First Name' });
+    this.lastTableRow = page.getByRole('row').last();
+    this.lastRowFirstNameCell = this.lastTableRow.getByRole('cell').nth(0);
+    this.lastRowLastNameCell = this.lastTableRow.getByRole('cell').nth(1);
+    this.lastRowPostalCodeCell = this.lastTableRow.getByRole('cell').nth(2);
+    this.lastRowAccountNumberCell = this.lastTableRow.getByRole('cell').nth(3);
   }
 
   async open() {
     await this.page.goto('/angularJs-protractor/BankingProject/#/manager/list');
+  }
+
+  async fillSearchInput(text) {
+    await this.searchInput.fill(text);
+  }
+
+  getDeleteButtonForRow(rowLocator) {
+    return rowLocator.getByRole('button', { name: 'Delete' });
+  }
+
+  async clickDeleteForCustomerRow(customerName) {
+    const row = this.page.getByRole('row').filter({ hasText: customerName });
+    await this.getDeleteButtonForRow(row).click();
+  }
+
+  async clickDeleteForLastRow() {
+    await this.getDeleteButtonForRow(this.lastTableRow).click();
+  }
+
+  async assertLastRowContainsFirstName(firstName) {
+    await expect(this.lastRowFirstNameCell).toContainText(firstName);
+  }
+
+  async assertLastRowContainsLastName(lastName) {
+    await expect(this.lastRowLastNameCell).toContainText(lastName);
+  }
+
+  async assertLastRowContainsPostalCode(postalCode) {
+    await expect(this.lastRowPostalCodeCell).toContainText(postalCode);
+  }
+
+  async assertLastRowAccountNumberIsEmpty() {
+    await expect(this.lastRowAccountNumberCell).toHaveText('');
+  }
+
+  async assertLastRowAccountNumberIsNotEmpty() {
+    await expect(this.lastRowAccountNumberCell).not.toHaveText('');
+  }
+
+  async assertCustomerRowIsPresent(customerName) {
+    const row = this.page.getByRole('row').filter({ hasText: customerName });
+    await expect(row).toBeVisible();
+  }
+
+  async assertCustomerRowIsNotPresent(customerName) {
+    const row = this.page.getByRole('row').filter({ hasText: customerName });
+    await expect(row).toBeHidden();
+  }
+
+  async assertOnlyOneRowIsPresent() {
+    await expect(this.tableRows).toHaveCount(1);
+  }
+
+  async assertRowCount(count) {
+    await expect(this.tableRows).toHaveCount(count);
   }
 }

--- a/src/pages/manager/OpenAccountPage.js
+++ b/src/pages/manager/OpenAccountPage.js
@@ -1,13 +1,32 @@
 import { expect } from '@playwright/test';
 
-export class AddCustomerPage {
+export class OpenAccountPage {
   constructor(page) {
     this.page = page;
+    this.customerSelect = page.getByTestId('userSelect');
+    this.currencySelect = page.getByTestId('currency');
+    this.processButton = page.getByRole('button', { name: 'Process' });
   }
 
   async open() {
     await this.page.goto(
       '/angularJs-protractor/BankingProject/#/manager/openAccount',
     );
+  }
+
+  async selectCustomer(customerName) {
+    await this.customerSelect.selectOption({ label: customerName });
+  }
+
+  async selectCurrency(currency) {
+    await this.currencySelect.selectOption(currency);
+  }
+
+  async clickProcessButton() {
+    await this.processButton.click();
+  }
+
+  async assertCurrencyDropdownHasValue(value) {
+    await expect(this.currencySelect).toHaveValue(value);
   }
 }

--- a/tests/customer/accountOperations/customerBalanceUpdatesCorrectlyAfterMultipleOperations.spec.js
+++ b/tests/customer/accountOperations/customerBalanceUpdatesCorrectlyAfterMultipleOperations.spec.js
@@ -15,15 +15,17 @@ test('Assert customer balance updates correctly after multiple operations', asyn
   await accountPage.clickDepositButton();
   await accountPage.fillAmountInputField('1000');
   await accountPage.clickDepositFormButton();
+  await accountPage.assertDepositSuccessfulMessageIsVisible();
 
   await accountPage.fillAmountInputField('500');
   await accountPage.clickDepositFormButton();
-  
+  await accountPage.assertDepositSuccessfulMessageIsVisible();
+
   await accountPage.assertAccountLineContainsText('Balance : 1500');
 
   await accountPage.clickWithdrawlButton();
   await accountPage.fillAmountInputField('700');
   await accountPage.clickWithdrawlFormButton();
-  
-  await accountPage.assertAccountLineContainsText('Balance : 800');
+  // Note: The app may not show a withdraw success message; balance assertion below validates completion.
+  await accountPage.assertAccountLineContainsText('Balance : 800', { timeout: 10000 });
 });

--- a/tests/customer/accountOperations/customerBalanceUpdatesCorrectlyAfterMultipleOperations.spec.js
+++ b/tests/customer/accountOperations/customerBalanceUpdatesCorrectlyAfterMultipleOperations.spec.js
@@ -1,0 +1,29 @@
+import { test } from '@playwright/test';
+import { CustomerLoginPage } from '../../../src/pages/customer/CustomerLoginPage';
+import { CustomerAccountPage } from '../../../src/pages/customer/CustomerAccountPage';
+
+test('Assert customer balance updates correctly after multiple operations', async ({ page }) => {
+  const customerLoginPage = new CustomerLoginPage(page);
+  const accountPage = new CustomerAccountPage(page);
+
+  await customerLoginPage.open();
+  await customerLoginPage.selectCustomer('Harry Potter');
+  await customerLoginPage.clickLoginButton();
+
+  await accountPage.assertAccountLineContainsText('Balance : 0');
+
+  await accountPage.clickDepositButton();
+  await accountPage.fillAmountInputField('1000');
+  await accountPage.clickDepositFormButton();
+
+  await accountPage.fillAmountInputField('500');
+  await accountPage.clickDepositFormButton();
+  
+  await accountPage.assertAccountLineContainsText('Balance : 1500');
+
+  await accountPage.clickWithdrawlButton();
+  await accountPage.fillAmountInputField('700');
+  await accountPage.clickWithdrawlFormButton();
+  
+  await accountPage.assertAccountLineContainsText('Balance : 800');
+});

--- a/tests/customer/accountOperations/customerCanSwitchAccounts.spec.js
+++ b/tests/customer/accountOperations/customerCanSwitchAccounts.spec.js
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test';
+import { CustomerLoginPage } from '../../../src/pages/customer/CustomerLoginPage';
+import { CustomerAccountPage } from '../../../src/pages/customer/CustomerAccountPage';
+
+test('Assert customer can switch between accounts', async ({ page }) => {
+  const customerLoginPage = new CustomerLoginPage(page);
+  const accountPage = new CustomerAccountPage(page);
+
+  await customerLoginPage.open();
+  await customerLoginPage.selectCustomer('Harry Potter');
+  await customerLoginPage.clickLoginButton();
+
+  const accounts = [
+    { id: '1004', currency: 'Dollar' },
+    { id: '1005', currency: 'Pound' },
+    { id: '1006', currency: 'Rupee' }
+  ];
+
+  for (const account of accounts) {
+    await accountPage.selectAccount(account.id);
+    await accountPage.assertAccountIdInDropDownHasValue(account.id);
+    await accountPage.assertAccountLineContainsText(`Account Number : ${account.id}`);
+    await accountPage.assertAccountLineContainsText(`Currency : ${account.currency}`);
+  }
+});

--- a/tests/customer/accountOperations/customerCanSwitchAccounts.spec.js
+++ b/tests/customer/accountOperations/customerCanSwitchAccounts.spec.js
@@ -11,15 +11,15 @@ test('Assert customer can switch between accounts', async ({ page }) => {
   await customerLoginPage.clickLoginButton();
 
   const accounts = [
-    { id: '1004', currency: 'Dollar' },
-    { id: '1005', currency: 'Pound' },
-    { id: '1006', currency: 'Rupee' }
+    { id: 'number:1004', currency: 'Dollar' },
+    { id: 'number:1005', currency: 'Pound' },
+    { id: 'number:1006', currency: 'Rupee' }
   ];
 
   for (const account of accounts) {
     await accountPage.selectAccount(account.id);
     await accountPage.assertAccountIdInDropDownHasValue(account.id);
-    await accountPage.assertAccountLineContainsText(`Account Number : ${account.id}`);
+    await accountPage.assertAccountLineContainsText(`Account Number : ${account.id.replace('number:', '')}`);
     await accountPage.assertAccountLineContainsText(`Currency : ${account.currency}`);
   }
 });

--- a/tests/customer/accountOperations/customerCanWithdrawMoney.spec.js
+++ b/tests/customer/accountOperations/customerCanWithdrawMoney.spec.js
@@ -1,0 +1,38 @@
+import { test } from '@playwright/test';
+import { CustomerLoginPage } from '../../../src/pages/customer/CustomerLoginPage';
+import { CustomerAccountPage } from '../../../src/pages/customer/CustomerAccountPage';
+import { TransactionsPage } from '../../../src/pages/customer/TransactionsPage';
+
+test('Assert the money can be withdrawn', async ({ page }) => {
+  const customerLoginPage = new CustomerLoginPage(page);
+  const accountPage = new CustomerAccountPage(page);
+  const transactionsPage = new TransactionsPage(page);
+
+  const depositAmount = 1000;
+  const withdrawAmount = 400;
+  const expectedBalance = depositAmount - withdrawAmount;
+
+  await customerLoginPage.open();
+  await customerLoginPage.selectCustomer('Harry Potter');
+  await customerLoginPage.clickLoginButton();
+
+  await accountPage.clickDepositButton();
+  await accountPage.fillAmountInputField(depositAmount.toString());
+  await accountPage.clickDepositFormButton();
+  await accountPage.assertDepositSuccessfulMessageIsVisible();
+
+  await accountPage.clickWithdrawlButton();
+  await accountPage.fillAmountInputField(withdrawAmount.toString());
+  await accountPage.clickWithdrawlFormButton();
+  await accountPage.assertWithdrawSuccessfulMessageIsVisible();
+
+  await accountPage.assertAccountLineContainsText(`Balance : ${expectedBalance}`);
+
+  await accountPage.clickTransactionsButton();
+  await transactionsPage.assertHeaderIsVisible();
+
+  await transactionsPage.waitForTransactionRows(2);
+
+  await transactionsPage.assertTransactionRowExists(depositAmount.toString(), 'Credit');
+  await transactionsPage.assertTransactionRowExists(withdrawAmount.toString(), 'Debit');
+});

--- a/tests/customer/logout/customerCanLogout.spec.js
+++ b/tests/customer/logout/customerCanLogout.spec.js
@@ -3,17 +3,16 @@ import { BankHomePage } from '../../../src/pages/BankHomePage';
 import { CustomerLoginPage } from '../../../src/pages/customer/CustomerLoginPage';
 import { CustomerAccountPage } from '../../../src/pages/customer/CustomerAccountPage';
 
-test('Assert correct customer Logout', async ({ page }) => {
-  /* 
-  Test:
+test('Customer Logout: user returns to customer select with empty dropdown', async ({ page }) => {
+  /*
+  Required test for customer Logout functionality:
   1. Open Wizard bank link
   2. Click [Customer Login]
   3. Select Neville Longbottom
   4. Click [Login]
   5. Click [Logout]
-  6. Wait for the page URL 
-  https://www.globalsqa.com/angularJs-protractor/BankingProject/#/customer
-  7. Assert the drop-down is present with empty value 
+  6. Wait for the page URL .../#/customer
+  7. Assert the dropdown is present with empty value
   */
   const bankHomePage = new BankHomePage(page);
   const customerLoginPage = new CustomerLoginPage(page);

--- a/tests/customer/transactions/customerCanResetTransactions.spec.js
+++ b/tests/customer/transactions/customerCanResetTransactions.spec.js
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test';
+import { CustomerLoginPage } from '../../../src/pages/customer/CustomerLoginPage';
+import { CustomerAccountPage } from '../../../src/pages/customer/CustomerAccountPage';
+import { TransactionsPage } from '../../../src/pages/customer/TransactionsPage';
+
+test('Assert customer can reset transactions', async ({ page }) => {
+  const customerLoginPage = new CustomerLoginPage(page);
+  const accountPage = new CustomerAccountPage(page);
+  const transactionsPage = new TransactionsPage(page);
+
+  await customerLoginPage.open();
+  await customerLoginPage.selectCustomer('Harry Potter');
+  await customerLoginPage.clickLoginButton();
+
+  await accountPage.clickDepositButton();
+  await accountPage.fillAmountInputField('500');
+  await accountPage.clickDepositFormButton();
+  await accountPage.assertDepositSuccessfulMessageIsVisible();
+
+  await accountPage.clickTransactionsButton();
+  await transactionsPage.assertHeaderIsVisible();
+  await transactionsPage.waitForTransactionRows(1);
+  await transactionsPage.assertFirstRowAmountContainsText('500');
+  
+  await transactionsPage.clickResetButton();
+  await transactionsPage.assertTableIsEmpty();
+});

--- a/tests/manager/addCustomer/managerCanAddNewCustomer.spec.js
+++ b/tests/manager/addCustomer/managerCanAddNewCustomer.spec.js
@@ -13,13 +13,12 @@ test('Assert manager can add new customer', async ({ page }) => {
   const lastName = faker.person.lastName();
   const postalCode = faker.location.zipCode();
 
+  page.once('dialog', (dialog) => dialog.accept());
+
   await addCustomerPage.open();
   await addCustomerPage.addCustomer(firstName, lastName, postalCode);
-  await page.reload();
   await managerMainPage.open();
   await managerMainPage.clickCustomersButton();
-  await customersListPage.assertLastRowContainsFirstName(firstName);
-  await customersListPage.assertLastRowContainsLastName(lastName);
-  await customersListPage.assertLastRowContainsPostalCode(postalCode);
-  await customersListPage.assertLastRowAccountNumberIsEmpty();
+  await customersListPage.assertCustomerRowContainsData(firstName, lastName, postalCode);
+  await customersListPage.assertCustomerRowAccountNumberEmpty(firstName, lastName, postalCode);
 });

--- a/tests/manager/addCustomer/managerCanAddNewCustomer.spec.js
+++ b/tests/manager/addCustomer/managerCanAddNewCustomer.spec.js
@@ -1,29 +1,25 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
 
 test('Assert manager can add new customer', async ({ page }) => {
-  /* 
-  Test:
-  1. Open add customer page by link
-    https://www.globalsqa.com/angularJs-protractor/BankingProject/#/manager/addCust
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  6. Reload the page (This is a simplified step to close the popup)
-  7. Click [Customers] button.
-  8. Assert the customer First Name is present in the table in the last row. 
-  9. Assert the customer Last Name is present in the table in the last row. 
-  10. Assert the customer Postal Code is present in the table in the last row. 
-  11. Assert there is no account number for the new customer in the last row. 
+  const addCustomerPage = new AddCustomerPage(page);
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
 
-  Tips:
-  1. Use faker for test data generation, example usage:
-    const firstName = faker.person.firstName();
-    const lastName = faker.person.LastName();
-    const postCode = faker.location.zipCode(); 
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  const postalCode = faker.location.zipCode();
 
-  2. Do not rely on the customer row id for the steps 8-11. 
-    Use the ".last()" locator to get the last row.
-  */
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
+  await page.reload();
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.assertLastRowContainsFirstName(firstName);
+  await customersListPage.assertLastRowContainsLastName(lastName);
+  await customersListPage.assertLastRowContainsPostalCode(postalCode);
+  await customersListPage.assertLastRowAccountNumberIsEmpty();
 });

--- a/tests/manager/addCustomer/managerCannotAddDuplicateCustomer.spec.js
+++ b/tests/manager/addCustomer/managerCannotAddDuplicateCustomer.spec.js
@@ -1,0 +1,31 @@
+import { test } from '@playwright/test';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+
+test('Assert manager cannot add duplicate customer', async ({ page }) => {
+  const addCustomerPage = new AddCustomerPage(page);
+
+  const firstName = 'Hermoine';
+  const lastName = 'Granger';
+  const postalCode = 'H101PP';
+
+  await addCustomerPage.open();
+
+  
+  page.once('dialog', async dialog => {
+    await dialog.accept();
+  });
+
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
+
+  let dialogMessage = '';
+  page.once('dialog', async dialog => {
+    dialogMessage = dialog.message();
+    await dialog.accept();
+  });
+
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
+  
+  if (dialogMessage !== 'Please check the details. Customer may be duplicate.') {
+    throw new Error(`Unexpected dialog message: ${dialogMessage}`);
+  }
+});

--- a/tests/manager/bankManagerLogin/managerCanLogin.spec.js
+++ b/tests/manager/bankManagerLogin/managerCanLogin.spec.js
@@ -1,13 +1,15 @@
 import { test } from '@playwright/test';
+import { BankHomePage } from '../../../src/pages/BankHomePage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
 
 test('Assert manager can Login', async ({ page }) => {
-  /* 
-  Test:
-  1. Open Wizard bank home page 
-    https://www.globalsqa.com/angularJs-protractor/BankingProject/#/login
-  2. Click [Bank Manager Login]
-  3. Assert button [Add Customer] is visible
-  4. Assert button [Open Account] is visible
-  5. Assert button [Customers] is visible
-  */
+
+  const bankHomePage = new BankHomePage(page);
+  const managerMainPage = new BankManagerMainPage(page);
+
+  await bankHomePage.open();
+  await bankHomePage.clickBankManagerLoginButton();
+  await managerMainPage.assertAddCustomerButtonIsVisible();
+  await managerMainPage.assertOpenAccountButtonIsVisible();
+  await managerMainPage.assertCustomersButtonIsVisible();
 });

--- a/tests/manager/deleteCustomer/managerCanDeleteCustomer.spec.js
+++ b/tests/manager/deleteCustomer/managerCanDeleteCustomer.spec.js
@@ -9,6 +9,8 @@ let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
+  page.once('dialog', (dialog) => dialog.accept());
+
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();
@@ -24,8 +26,8 @@ test('Assert manager can delete customer', async ({ page }) => {
 
   await managerMainPage.open();
   await managerMainPage.clickCustomersButton();
-  await customersListPage.clickDeleteForCustomerRow(firstName);
-  await customersListPage.assertCustomerRowIsNotPresent(firstName);
+  await customersListPage.clickDeleteForCustomer(firstName, lastName, postalCode);
+  await customersListPage.assertCustomerRowNotPresent(firstName, lastName, postalCode);
   await page.reload();
-  await customersListPage.assertCustomerRowIsNotPresent(firstName);
+  await customersListPage.assertCustomerRowNotPresent(firstName, lastName, postalCode);
 });

--- a/tests/manager/deleteCustomer/managerCanDeleteCustomer.spec.js
+++ b/tests/manager/deleteCustomer/managerCanDeleteCustomer.spec.js
@@ -1,24 +1,31 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
+
+let firstName;
+let lastName;
+let postalCode;
 
 test.beforeEach(async ({ page }) => {
-  /* 
-  Pre-conditons:
-  1. Open Add Customer page.
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  */
+  firstName = faker.person.firstName();
+  lastName = faker.person.lastName();
+  postalCode = faker.location.zipCode();
+
+  const addCustomerPage = new AddCustomerPage(page);
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
 });
 
 test('Assert manager can delete customer', async ({ page }) => {
-  /* 
-  Test:
-  1. Open Customers page.
-  2. Click [Delete] for the row with customer name.
-  3. Assert customer row is not present in the table. 
-  4. Reload the page.
-  5. Assert customer row is not present in the table. 
-  */
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
+
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.clickDeleteForCustomerRow(firstName);
+  await customersListPage.assertCustomerRowIsNotPresent(firstName);
+  await page.reload();
+  await customersListPage.assertCustomerRowIsNotPresent(firstName);
 });

--- a/tests/manager/openAccount/managerCanChooseCurrencies.spec.js
+++ b/tests/manager/openAccount/managerCanChooseCurrencies.spec.js
@@ -1,16 +1,14 @@
 import { test } from '@playwright/test';
-import { faker } from '@faker-js/faker';
+import { OpenAccountPage } from '../../../src/pages/manager/OpenAccountPage';
 
 test('Assert manager can choose currencies for account', async ({ page }) => {
-  /* 
-  Test:
-  1. Open the Open account page 
-    https://www.globalsqa.com/angularJs-protractor/BankingProject/#/manager/openAccount
-  2. Select currency Dollar
-  3. Assert the drop-dwon has value Dollar
-  4. Select currency Pound
-  5. Assert the drop-dwon has value Pound
-  6. Select currency Rupee
-  7. Assert the drop-dwon has value Rupee
-  */
+  const openAccountPage = new OpenAccountPage(page);
+
+  await openAccountPage.open();
+  await openAccountPage.selectCurrency('Dollar');
+  await openAccountPage.assertCurrencyDropdownHasValue('Dollar');
+  await openAccountPage.selectCurrency('Pound');
+  await openAccountPage.assertCurrencyDropdownHasValue('Pound');
+  await openAccountPage.selectCurrency('Rupee');
+  await openAccountPage.assertCurrencyDropdownHasValue('Rupee');
 });

--- a/tests/manager/openAccount/managerCanOpenAccount.spec.js
+++ b/tests/manager/openAccount/managerCanOpenAccount.spec.js
@@ -10,6 +10,8 @@ let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
+  page.once('dialog', (dialog) => dialog.accept());
+
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();
@@ -17,10 +19,9 @@ test.beforeEach(async ({ page }) => {
   const addCustomerPage = new AddCustomerPage(page);
   await addCustomerPage.open();
   await addCustomerPage.addCustomer(firstName, lastName, postalCode);
-  await page.reload();
 });
 
-test('Assert manager can add new customer', async ({ page }) => {
+test('Assert manager can open a new account for a customer', async ({ page }) => {
   const customerFullName = `${firstName} ${lastName}`;
   const managerMainPage = new BankManagerMainPage(page);
   const openAccountPage = new OpenAccountPage(page);
@@ -30,8 +31,10 @@ test('Assert manager can add new customer', async ({ page }) => {
   await managerMainPage.clickOpenAccountButton();
   await openAccountPage.selectCustomer(customerFullName);
   await openAccountPage.selectCurrency('Dollar');
+
+  page.once('dialog', (dialog) => dialog.accept());
   await openAccountPage.clickProcessButton();
-  await page.reload();
+
   await managerMainPage.clickCustomersButton();
-  await customersListPage.assertLastRowAccountNumberIsNotEmpty();
+  await customersListPage.assertCustomerRowAccountNumberNotEmpty(firstName, lastName, postalCode);
 });

--- a/tests/manager/openAccount/managerCanOpenAccount.spec.js
+++ b/tests/manager/openAccount/managerCanOpenAccount.spec.js
@@ -1,31 +1,37 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { OpenAccountPage } from '../../../src/pages/manager/OpenAccountPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
+
+let firstName;
+let lastName;
+let postalCode;
 
 test.beforeEach(async ({ page }) => {
-  /* 
-  Pre-conditons:
-  1. Open Add Customer page
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  6. Reload the page (This is a simplified step to close the popup).
-  */
+  firstName = faker.person.firstName();
+  lastName = faker.person.lastName();
+  postalCode = faker.location.zipCode();
+
+  const addCustomerPage = new AddCustomerPage(page);
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
+  await page.reload();
 });
 
 test('Assert manager can add new customer', async ({ page }) => {
-  /* 
-  Test:
-  1. Click [Open Account].
-  2. Select Customer name you just created.
-  3. Select currency.
-  4. Click [Process].
-  5. Reload the page (This is a simplified step to close the popup).
-  6. Click [Customers].
-  7. Assert the customer row has the account number not empty.
+  const customerFullName = `${firstName} ${lastName}`;
+  const managerMainPage = new BankManagerMainPage(page);
+  const openAccountPage = new OpenAccountPage(page);
+  const customersListPage = new CustomersListPage(page);
 
-  Tips:
-  1. Do not rely on the customer row id for the step 13. 
-    Use the ".last()" locator to get the last row.
-  */
+  await managerMainPage.open();
+  await managerMainPage.clickOpenAccountButton();
+  await openAccountPage.selectCustomer(customerFullName);
+  await openAccountPage.selectCurrency('Dollar');
+  await openAccountPage.clickProcessButton();
+  await page.reload();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.assertLastRowAccountNumberIsNotEmpty();
 });

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByFirstName.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByFirstName.spec.js
@@ -1,30 +1,30 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
 
 let firstName;
 let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
-  /* 
-  Pre-conditons:
-  1. Open Add Customer page.
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  */
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();
+
+  const addCustomerPage = new AddCustomerPage(page);
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
 });
 
 test('Assert manager can search customer by First Name', async ({ page }) => {
-  /* 
-  Test:
-  1. Open Customers page.
-  2. Fill the firstName to the search field
-  3. Assert customer row is present in the table. 
-  4. Assert no other rows is present in the table.
-  */
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
+
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.fillSearchInput(firstName);
+  await customersListPage.assertCustomerRowIsPresent(firstName);
+  await customersListPage.assertOnlyOneRowIsPresent();
 });

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByFirstName.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByFirstName.spec.js
@@ -9,6 +9,8 @@ let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
+  page.once('dialog', (dialog) => dialog.accept());
+
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByLastName.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByLastName.spec.js
@@ -1,30 +1,30 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
 
 let firstName;
 let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
-  /* 
-  Pre-conditons:
-  1. Open Add Customer page
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  */
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();
+
+  const addCustomerPage = new AddCustomerPage(page);
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
 });
 
 test('Assert manager can search customer by Last Name', async ({ page }) => {
-  /* 
-  Test:
-  1. Open Customers page
-  2. Fill the lastName to the search field
-  3. Assert customer row is present in the table. 
-  4. Assert no other rows is present in the table.
-  */
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
+
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.fillSearchInput(lastName);
+  await customersListPage.assertCustomerRowIsPresent(lastName);
+  await customersListPage.assertOnlyOneRowIsPresent();
 });

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByLastName.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByLastName.spec.js
@@ -9,6 +9,8 @@ let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
+  page.once('dialog', (dialog) => dialog.accept());
+
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByPostalCode.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByPostalCode.spec.js
@@ -9,6 +9,8 @@ let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
+  page.once('dialog', (dialog) => dialog.accept());
+
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();

--- a/tests/manager/searchCustomer/managerCanSearchCustomerByPostalCode.spec.js
+++ b/tests/manager/searchCustomer/managerCanSearchCustomerByPostalCode.spec.js
@@ -1,30 +1,30 @@
 import { test } from '@playwright/test';
 import { faker } from '@faker-js/faker';
+import { AddCustomerPage } from '../../../src/pages/manager/AddCustomerPage';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
 
 let firstName;
 let lastName;
 let postalCode;
 
 test.beforeEach(async ({ page }) => {
-  /* 
-  Pre-conditons:
-  1. Open Add Customer page.
-  2. Fill the First Name.  
-  3. Fill the Last Name.
-  4. Fill the Postal Code.
-  5. Click [Add Customer].
-  */
   firstName = faker.person.firstName();
   lastName = faker.person.lastName();
   postalCode = faker.location.zipCode();
+
+  const addCustomerPage = new AddCustomerPage(page);
+  await addCustomerPage.open();
+  await addCustomerPage.addCustomer(firstName, lastName, postalCode);
 });
 
 test('Assert manager can search customer by Postal Code', async ({ page }) => {
-  /* 
-  Test:
-  1. Open Customers page.
-  2. Fill the postalCode to the search field
-  3. Assert customer row is present in the table. 
-  4. Assert no other rows is present in the table.
-  */
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
+
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  await customersListPage.fillSearchInput(postalCode);
+  await customersListPage.assertCustomerRowIsPresent(postalCode);
+  await customersListPage.assertOnlyOneRowIsPresent();
 });

--- a/tests/manager/searchCustomer/managerSearchReturnsNoResults.spec.js
+++ b/tests/manager/searchCustomer/managerSearchReturnsNoResults.spec.js
@@ -1,0 +1,14 @@
+import { test } from '@playwright/test';
+import { BankManagerMainPage } from '../../../src/pages/manager/BankManagerMainPage';
+import { CustomersListPage } from '../../../src/pages/manager/CustomersListPage';
+
+test('Assert search returns no results for non-existent customer', async ({ page }) => {
+  const managerMainPage = new BankManagerMainPage(page);
+  const customersListPage = new CustomersListPage(page);
+
+  await managerMainPage.open();
+  await managerMainPage.clickCustomersButton();
+  
+  await customersListPage.fillSearchInput('NonExistentCustomerName');
+  await customersListPage.assertRowCount(0);
+});


### PR DESCRIPTION
Implement manager page objects (BankManagerMainPage, AddCustomerPage,
OpenAccountPage, CustomersListPage) and all manager specs (login, add/delete
customer, open account, currencies, search by first/last name/postal code).
Add Bank Manager Login to BankHomePage. Extend TransactionsPage with
assertTransactionRowExists, waitForTransactionRows, Reset and assertTableIsEmpty.
Add customer withdraw and reset transaction tests; keep deposit/reset using
reload + first-row assertions. Include extra coverage (e.g. switch accounts,
multiple operations, duplicate customer, search no results).